### PR TITLE
added if statement in onRemove() function

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -610,7 +610,7 @@ export default class GoogleMap extends Component {
           },
 
           onRemove() {
-            ReactDOM.unmountComponentAtNode(this.div);
+            if(this.div) ReactDOM.unmountComponentAtNode(this.div);
           },
 
           draw() {


### PR DESCRIPTION
Added an if statement in `onRemove()` function that checks if `this.div` is defined before calling `ReactDOM.unmountComponentAtNode(this.div`). This is done to avoid throwing an `unmountComponentAtNode(...): Target container is not a DOM element` error. I ran into this error while using google-map-react with React Router and switching between tabs rapidly to stress test my application.