### PR TITLE
Use our own omit.js

### DIFF
--- a/develop/utils/omit.js
+++ b/develop/utils/omit.js
@@ -1,0 +1,13 @@
+// https://github.com/acdlite/recompose/blob/master/src/packages/recompose/utils/omit.js
+const omit = (obj, keys) => {
+  const { ...rest } = obj;
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    if (key in rest) {
+      delete rest[key];
+    }
+  }
+  return rest;
+};
+
+export default omit;

--- a/develop/utils/props2Stream.js
+++ b/develop/utils/props2Stream.js
@@ -1,5 +1,5 @@
 import { Component } from 'react';
-import omit from 'lodash.omit';
+import omit from './omit';
 
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import 'rxjs/add/operator/distinctUntilChanged';

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "jsdom": "^6.5.1",
     "kotatsu": "^0.14.0",
     "lint-staged": "^3.4.0",
-    "lodash.omit": "^4.5.0",
     "mocha": "^2.3.3",
     "node-sass": "^3.7.0",
     "normalize.css": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3431,10 +3431,6 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
-lodash.omit@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
-
 lodash.pickby@^4.0.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"


### PR DESCRIPTION
Refs: https://github.com/google-map-react/google-map-react/issues/558#issuecomment-380595616

Removes lodash completely as omit it is going away in lodash 5: https://github.com/lodash/lodash/issues/2930