### PR TITLE
Move react-dom to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
   "dependencies": {
     "@mapbox/point-geometry": "^0.1.0",
     "eventemitter3": "^1.1.0",
-    "scriptjs": "^2.5.7"
+    "scriptjs": "^2.5.7",
+    "react-dom": "^16.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.6",
@@ -85,7 +86,6 @@
     "prettier": "^0.22.0",
     "prop-types": "^15.5.6",
     "react": "^16.0.0",
-    "react-dom": "^16.0.0",
     "react-motion": "^0.4.4",
     "react-router": "^3.2.0",
     "recompose": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -43,13 +43,13 @@
   "homepage": "https://github.com/google-map-react/google-map-react#readme",
   "peerDependencies": {
     "prop-types": "^15.5.6",
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "dependencies": {
     "@mapbox/point-geometry": "^0.1.0",
     "eventemitter3": "^1.1.0",
-    "scriptjs": "^2.5.7",
-    "react-dom": "^16.0.0"
+    "scriptjs": "^2.5.7"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.6",


### PR DESCRIPTION
React-dom is required by [src/google_map.js](https://github.com/google-map-react/google-map-react/blob/master/src/google_map.js#L4). But it was not listed as peerDependency, because of this, we were not able to use Google-map-react in a project that does not have `react-dom` as a dependency. 