### PR TITLE
Option to position and size components with two corners.

### DIFF
--- a/src/google_map_markers.js
+++ b/src/google_map_markers.js
@@ -274,6 +274,9 @@ export default class GoogleMapMarkers extends Component {
           top: pt.y,
         };
 
+        // If the component has a southeast corner defined (either as a LatLng, or a separate
+        // lat and lng pair), set the width and height based on the distance between the northwest
+        // and the southeast corner to lock the overlay to the correct geographic bounds.
         if (
           child.props.seLatLng !== undefined ||
           (

--- a/src/google_map_markers.js
+++ b/src/google_map_markers.js
@@ -269,10 +269,29 @@ export default class GoogleMapMarkers extends Component {
           ? this.props.geoService.fromLatLngToContainerPixel(latLng)
           : this.props.geoService.project(latLng);
 
-        const stylePtPos = {
+        let stylePtPos = {
           left: pt.x,
           top: pt.y,
         };
+
+        if (
+          child.props.seLatLng !== undefined ||
+          (
+            child.props.seLat !== undefined &&
+            child.props.seLng !== undefined
+          )
+        ) {
+          const seLatLng = child.props.seLatLng !== undefined
+            ? child.props.seLatLng
+            : {lat: child.props.seLat, lng: child.props.seLng};
+
+          const sePt = this.props.projectFromLeftTop
+            ? this.props.geoService.fromLatLngToContainerPixel(seLatLng)
+            : this.props.geoService.project(seLatLng);
+
+          stylePtPos.width = sePt.x - pt.x;
+          stylePtPos.height = sePt.y - pt.y;
+        }
 
         let dx = 0;
         let dy = 0;


### PR DESCRIPTION
This lets you lock a component to a specific bounding rectangle, which allows for precise tiling during zoom with the experimental google maps API.

I work on a project that uses a technique similar to the thousands-of-markers sample project linked to from the readme.  If you run that project against the 3.32 google maps API you can see the same issue I was having.  The tiles are not scaled when frames are drawn during a zoom, which causes the edges to either have gaps between them, or to overlap.  This adds the option to specify a second LatLng (the southeast corner) to give a component a bounds-locked box to render into.

Here is a before example:
![giphy](https://user-images.githubusercontent.com/1094861/40006767-d4615f5a-5760-11e8-9540-b2f328d76ff1.gif)

And after:
![giphy-1](https://user-images.githubusercontent.com/1094861/40006897-1bd907ac-5761-11e8-99e7-f6b3e97aa0b4.gif)


