### PR TITLE
Move dep for react-dom

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
   "homepage": "https://github.com/google-map-react/google-map-react#readme",
   "peerDependencies": {
     "prop-types": "^15.5.6",
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "@mapbox/point-geometry": "^0.1.0",
     "eventemitter3": "^1.1.0",
-    "react-dom": "^16.3.2",
     "scriptjs": "^2.5.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4512,15 +4512,6 @@ react-deep-force-update@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz#bcd31478027b64b3339f108921ab520b4313dc2c"
 
-react-dom@^16.3.2:
-  version "16.3.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.2.tgz#cb90f107e09536d683d84ed5d4888e9640e0e4df"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 react-motion@^0.4.4:
   version "0.4.8"
   resolved "https://registry.yarnpkg.com/react-motion/-/react-motion-0.4.8.tgz#23bb2dd27c2d8e00d229e45572d105efcf40a35e"


### PR DESCRIPTION
`react-dom` should be a `peerDep` and not a `dependancy`

Consumers should be deciding if they want to include this as part of their bundle not the library