### PR TITLE
Add guard around mapDom event listener

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -249,11 +249,10 @@ export default class GoogleMap extends Component {
     const mapDom = ReactDOM.findDOMNode(this.googleMapDom_);
     // gmap can't prevent map drag if mousedown event already occured
     // the only workaround I find is prevent mousedown native browser event
-    ReactDOM.findDOMNode(this.googleMapDom_).addEventListener(
-      'mousedown',
-      this._onMapMouseDownNative,
-      true
-    );
+
+    if (mapDom) {
+      mapDom.addEventListener('mousedown', this._onMapMouseDownNative, true);
+    }
 
     window.addEventListener('mouseup', this._onChildMouseUp, false);
 


### PR DESCRIPTION
Fixes an issue where, even if the end user has a proper google maps API
mock, the GoogleMaps component will throw an error when in a test
env.  ReactDOM.findDOMNode(this.googleMapDom_) returns `null`.

This commit wraps the subsequent addEventListener call in an `if` block,
ensuring that an empty DOM doesn't add complications to test suites

Thank you for your consideration and your hard work on this great library!