### PR TITLE
Fix javascript typo

### DIFF
--- a/API.md
+++ b/API.md
@@ -240,9 +240,9 @@ Example (centering the marker):
 ```javascript
 const greatPlaceStyle = {
   position: 'absolute',
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  top: '50%';
+  left: '50%';
+  transform: 'translate(-50%, -50%)';
 }
 ```
 


### PR DESCRIPTION
People copy-paste a lot so we don't want them to get confused.