### PR TITLE
Update API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -240,8 +240,6 @@ Example (centering the marker):
 ```javascript
 const greatPlaceStyle = {
   position: 'absolute',
-  top: '50%';
-  left: '50%';
   transform: 'translate(-50%, -50%)';
 }
 ```


### PR DESCRIPTION
Because the parent node of marker has size 0x0, top 50% and right 50% would affect nothing. You only need to translate(-50%, -50%) to move it to the right position.