### PR TITLE
Update API.md

### DIFF
--- a/API.md
+++ b/API.md
@@ -4,7 +4,7 @@
 
 #### apiKey (string) (_Deprecated use bootstrapURLKeys_)
 
-Google maps api key. (Optional, but your map will be rate-limited with no key)
+Google maps api key.
 
 #### bootstrapURLKeys (object)
 


### PR DESCRIPTION
Since June 11 2018 all Google Maps Platform API requests must include an API key.
https://developers.google.com/maps/documentation/javascript/usage-and-billing