### PR TITLE
Add prop `onTilesLoaded`

### DIFF
--- a/API.md
+++ b/API.md
@@ -139,6 +139,7 @@ When the user changes the map type (HYBRID, ROADMAP, SATELLITE, TERRAIN) this fi
 Directly access the maps API - *use at your own risk!*
 
 #### onTilesLoaded (func)
+This function is called when the visible tiles have finished loading.
 
 ```javascript
 <GoogleMap  onGoogleApiLoaded={({map, maps}) => console.log(map, maps)} />

--- a/API.md
+++ b/API.md
@@ -138,6 +138,8 @@ When the user changes the map type (HYBRID, ROADMAP, SATELLITE, TERRAIN) this fi
 #### onGoogleApiLoaded (func)
 Directly access the maps API - *use at your own risk!*
 
+#### onTilesLoaded (func)
+
 ```javascript
 <GoogleMap  onGoogleApiLoaded={({map, maps}) => console.log(map, maps)} />
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 Add [google-map-clustering-example](https://github.com/istarkov/google-map-clustering-example)
 
-###[Unreleased]
 Add prop `onTilesLoaded` to react on the `tilesloaded` event
 
 ###0.9v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Add [google-map-clustering-example](https://github.com/istarkov/google-map-clustering-example)
 
-###1.1.0v
+###[Unreleased]
 Add prop `onTilesLoaded` to react on the `tilesloaded` event
 
 ###0.9v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Add [google-map-clustering-example](https://github.com/istarkov/google-map-clustering-example)
 
+###1.1.0v
+Add prop `onTilesLoaded` to react on the `tilesloaded` event
+
 ###0.9v
 
 Add: `bootstrapURLKeys` (object) instead of `apiKey` prop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jfw/google-map-react",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "isomorphic google map react component, allows render react components on the google map",
   "main": "lib/index",
   "scripts": {
@@ -103,5 +103,9 @@
       "prettier --trailing-comma es5 --single-quote --write",
       "git add"
     ]
+  },
+  "directories": {
+    "lib": "lib",
+    "test": "test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "google-map-react",
+  "name": "@jfw/google-map-react",
   "version": "1.0.5",
   "description": "isomorphic google map react component, allows render react components on the google map",
   "main": "lib/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-map-react",
-  "version": "2.0.0",
+  "version": "1.0.5",
   "description": "isomorphic google map react component, allows render react components on the google map",
   "main": "lib/index",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -103,9 +103,5 @@
       "prettier --trailing-comma es5 --single-quote --write",
       "git add"
     ]
-  },
-  "directories": {
-    "lib": "lib",
-    "test": "test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-map-react",
-  "version": "1.0.5",
+  "version": "2.0.0",
   "description": "isomorphic google map react component, allows render react components on the google map",
   "main": "lib/index",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@jfw/google-map-react",
-  "version": "1.0.6",
+  "name": "google-map-react",
+  "version": "1.0.5",
   "description": "isomorphic google map react component, allows render react components on the google map",
   "main": "lib/index",
   "scripts": {

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -502,7 +502,6 @@ export default class GoogleMap extends Component {
           return;
         }
 
-
         const centerLatLng = this.geoService_.getCenter();
 
         const propsOptions = {
@@ -602,7 +601,6 @@ export default class GoogleMap extends Component {
               maps,
               overlay.getProjection()
             );
-
             ReactDOM.unstable_renderSubtreeIntoContainer(
               this_,
               <GoogleMapMarkers
@@ -663,7 +661,6 @@ export default class GoogleMap extends Component {
         if (this.props.heatmap.positions) {
           this.heatmap.setMap(map);
         }
-
 
         maps.event.addListener(map, 'tilesloaded', () => {
           this_._onTilesLoaded();
@@ -803,8 +800,7 @@ export default class GoogleMap extends Component {
   _onZoomAnimationEnd = (...args) =>
     this.props.onZoomAnimationEnd && this.props.onZoomAnimationEnd(...args);
 
-  _onTilesLoaded = () =>
-    this.props.onTilesLoaded && this.props.onTilesLoaded();
+  _onTilesLoaded = () => this.props.onTilesLoaded && this.props.onTilesLoaded();
 
   _onChildClick = (...args) => {
     if (this.props.onChildClick) {

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -118,6 +118,7 @@ export default class GoogleMap extends Component {
     onZoomAnimationEnd: PropTypes.func,
     onDrag: PropTypes.func,
     onMapTypeIdChange: PropTypes.func,
+    onTilesLoaded: PropTypes.func,
     options: PropTypes.any,
     distanceToMouse: PropTypes.func,
     hoverDistance: PropTypes.number,
@@ -255,7 +256,6 @@ export default class GoogleMap extends Component {
     }
 
     window.addEventListener('mouseup', this._onChildMouseUp, false);
-
     const bootstrapURLKeys = {
       ...(this.props.apiKey && { key: this.props.apiKey }),
       ...this.props.bootstrapURLKeys,
@@ -502,6 +502,7 @@ export default class GoogleMap extends Component {
           return;
         }
 
+
         const centerLatLng = this.geoService_.getCenter();
 
         const propsOptions = {
@@ -663,6 +664,11 @@ export default class GoogleMap extends Component {
           this.heatmap.setMap(map);
         }
 
+
+        maps.event.addListener(map, 'tilesloaded', () => {
+          this_._onTilesLoaded();
+        });
+
         maps.event.addListener(map, 'zoom_changed', () => {
           // recalc position at zoom start
           if (this_.geoService_.getZoom() !== map.getZoom()) {
@@ -796,6 +802,9 @@ export default class GoogleMap extends Component {
 
   _onZoomAnimationEnd = (...args) =>
     this.props.onZoomAnimationEnd && this.props.onZoomAnimationEnd(...args);
+
+  _onTilesLoaded = () =>
+    this.props.onTilesLoaded && this.props.onTilesLoaded();
 
   _onChildClick = (...args) => {
     if (this.props.onChildClick) {

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -662,9 +662,11 @@ export default class GoogleMap extends Component {
           this.heatmap.setMap(map);
         }
 
-        maps.event.addListener(map, 'tilesloaded', () => {
-          this_._onTilesLoaded();
-        });
+        if (this.props.onTilesLoaded) {
+          maps.event.addListener(map, 'tilesloaded', () => {
+            this_._onTilesLoaded();
+          });
+        }
 
         maps.event.addListener(map, 'zoom_changed', () => {
           // recalc position at zoom start


### PR DESCRIPTION
There are [some events](https://developers.google.com/maps/documentation/javascript/events) that are fired by the Google Maps JavaScript API, but there are not available on the React component. With this PR, I'm passing through the event `tilesloaded`.

Please let me know what you think about this. I'd love to see my changes upstream.