### PR TITLE
Updating map center when props changes during map initialization

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -507,7 +507,7 @@ export default class GoogleMap extends Component {
         }
 
         const centerLatLng = this.pendingProps_
-          ? this.pendingProps_.center
+          ? latLng2Obj(this.pendingProps_.center)
           : this.geoService_.getCenter();
 
         const propsOptions = {

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -195,6 +195,8 @@ export default class GoogleMap extends Component {
 
     this.googleMapDom_ = null;
 
+    this.pendingProps_ = null;
+
     if (process.env.NODE_ENV !== 'production') {
       if (this.props.apiKey) {
         console.warn(
@@ -373,6 +375,8 @@ export default class GoogleMap extends Component {
         });
         this._setLayers(nextProps.layerTypes);
       }
+    } else {
+      this.pendingProps_ = nextProps;
     }
   }
 
@@ -502,7 +506,9 @@ export default class GoogleMap extends Component {
           return;
         }
 
-        const centerLatLng = this.geoService_.getCenter();
+        const centerLatLng = this.pendingProps_
+          ? this.pendingProps_.center
+          : this.geoService_.getCenter();
 
         const propsOptions = {
           zoom: this.props.zoom || this.props.defaultZoom,


### PR DESCRIPTION
When `center` prop changed during map initialization, old coordinates from old `center` props was active. In this PR I've added code to 
1. Store new props passed to component during map initialization.
2. Use newest center prop when map is rendered first time.