### PR TITLE
Use React 16 portal to render map overlay

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
   "homepage": "https://github.com/google-map-react/google-map-react#readme",
   "peerDependencies": {
     "prop-types": "^15.5.6",
-    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "dependencies": {
     "@mapbox/point-geometry": "^0.1.0",

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -239,7 +239,7 @@ export default class GoogleMap extends Component {
     this.zoomAnimationInProgress_ = false;
 
     this.state = {
-      overlayCreated: false,
+      div: null,
     };
   }
 
@@ -601,27 +601,19 @@ export default class GoogleMap extends Component {
               maps,
               overlay.getProjection()
             );
-            ReactDOM.unstable_renderSubtreeIntoContainer(
-              this_,
-              <GoogleMapMarkers
-                experimental={this_.props.experimental}
-                onChildClick={this_._onChildClick}
-                onChildMouseDown={this_._onChildMouseDown}
-                onChildMouseEnter={this_._onChildMouseEnter}
-                onChildMouseLeave={this_._onChildMouseLeave}
-                geoService={this_.geoService_}
-                insideMapPanes
-                distanceToMouse={this_.props.distanceToMouse}
-                getHoverDistance={this_._getHoverDistance}
-                dispatcher={this_.markersDispatcher_}
-              />,
+
+            this_.setState(state => ({
+              ...state,
               div,
-              // remove prerendered markers
-              () => this_.setState({ overlayCreated: true })
-            );
+            }));
           },
 
           onRemove() {
+            this_.setState(state => ({
+              ...state,
+              div: null,
+            }));
+
             if (this.div) {
               ReactDOM.unmountComponentAtNode(this.div);
             }
@@ -1062,7 +1054,7 @@ export default class GoogleMap extends Component {
   };
 
   render() {
-    const mapMarkerPrerender = !this.state.overlayCreated
+    const mapMarkerPrerender = !this.state.div
       ? <GoogleMapMarkersPrerender
           experimental={this.props.experimental}
           onChildClick={this._onChildClick}
@@ -1085,6 +1077,22 @@ export default class GoogleMap extends Component {
         onClick={this._onMapClick}
       >
         <GoogleMapMap registerChild={this._registerChild} />
+        {this.state.div &&
+          ReactDOM.createPortal(
+            <GoogleMapMarkers
+              experimental={this.props.experimental}
+              onChildClick={this._onChildClick}
+              onChildMouseDown={this._onChildMouseDown}
+              onChildMouseEnter={this._onChildMouseEnter}
+              onChildMouseLeave={this._onChildMouseLeave}
+              geoService={this.geoService_}
+              insideMapPanes
+              distanceToMouse={this.props.distanceToMouse}
+              getHoverDistance={this._getHoverDistance}
+              dispatcher={this.markersDispatcher_}
+            />,
+            this.state.div
+          )}
 
         {/* render markers before map load done */}
         {mapMarkerPrerender}

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -239,7 +239,7 @@ export default class GoogleMap extends Component {
     this.zoomAnimationInProgress_ = false;
 
     this.state = {
-      div: null,
+      overlay: null,
     };
   }
 
@@ -587,7 +587,7 @@ export default class GoogleMap extends Component {
               : '2000px';
 
             const div = document.createElement('div');
-            this.div = div;
+            this.overlay = div;
             div.style.backgroundColor = 'transparent';
             div.style.position = 'absolute';
             div.style.left = '0px';
@@ -604,18 +604,18 @@ export default class GoogleMap extends Component {
 
             this_.setState(state => ({
               ...state,
-              div,
+              overlay: div,
             }));
           },
 
           onRemove() {
             this_.setState(state => ({
               ...state,
-              div: null,
+              overlay: null,
             }));
 
-            if (this.div) {
-              ReactDOM.unmountComponentAtNode(this.div);
+            if (this.overlay) {
+              ReactDOM.unmountComponentAtNode(this.overlay);
             }
           },
 
@@ -1054,7 +1054,7 @@ export default class GoogleMap extends Component {
   };
 
   render() {
-    const mapMarkerPrerender = !this.state.div
+    const mapMarkerPrerender = !this.state.overlay
       ? <GoogleMapMarkersPrerender
           experimental={this.props.experimental}
           onChildClick={this._onChildClick}
@@ -1077,7 +1077,7 @@ export default class GoogleMap extends Component {
         onClick={this._onMapClick}
       >
         <GoogleMapMap registerChild={this._registerChild} />
-        {this.state.div &&
+        {this.state.overlay &&
           ReactDOM.createPortal(
             <GoogleMapMarkers
               experimental={this.props.experimental}
@@ -1091,7 +1091,7 @@ export default class GoogleMap extends Component {
               getHoverDistance={this._getHoverDistance}
               dispatcher={this.markersDispatcher_}
             />,
-            this.state.div
+            this.state.overlay
           )}
 
         {/* render markers before map load done */}


### PR DESCRIPTION
This allows the new context API to propagate context properly.

Fixes #642.

Note: This is a breaking change since it will no longer support React < 16 and should be released as a new major version.