### PR TITLE
Fix/library loader

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -298,9 +298,11 @@ export default class GoogleMap extends Component {
     }
 
     if (
-      !this._isCenterDefined(this.props.center) &&
-      this._isCenterDefined(nextProps.center)
+      (!this._isCenterDefined(this.props.center) &&
+        this._isCenterDefined(nextProps.center)) ||
+      this.props.updateHeatmap
     ) {
+      this.initialized_ = this.props.updateHeatmap ? false : this.initialized_;
       setTimeout(() => this._initMap(), 0);
     }
 

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -153,7 +153,12 @@ export default class GoogleMap extends Component {
     },
     layerTypes: [],
     heatmap: {},
-    heatmapLibrary: false,
+    libraries: {
+      visualization: false,
+      geometry: false,
+      places: false,
+      drawing: false,
+    },
   };
 
   static googleMapLoader = googleMapLoader; // eslint-disable-line
@@ -260,8 +265,14 @@ export default class GoogleMap extends Component {
       ...(this.props.apiKey && { key: this.props.apiKey }),
       ...this.props.bootstrapURLKeys,
     };
-
-    this.props.googleMapLoader(bootstrapURLKeys, this.props.heatmapLibrary); // we can start load immediatly
+    const libraries = {
+      visualization: this.props.heatmapLibrary,
+      geometry: this.props.geometryLibrary,
+      places: this.props.placesLibrary,
+      drawing: this.props.drawingLibrary,
+    };
+    this.props.googleMapLoader(bootstrapURLKeys, libraries);
+    // we can start load immediatly
 
     setTimeout(
       () => {
@@ -297,12 +308,14 @@ export default class GoogleMap extends Component {
       }
     }
 
+    if (this.props.updateHeatmap) {
+      setTimeout(() => optionsHeatmap(this.heatmap, this.props.heatmap));
+    }
+
     if (
-      (!this._isCenterDefined(this.props.center) &&
-        this._isCenterDefined(nextProps.center)) ||
-      this.props.updateHeatmap
+      !this._isCenterDefined(this.props.center) &&
+      this._isCenterDefined(nextProps.center)
     ) {
-      this.initialized_ = this.props.updateHeatmap ? false : this.initialized_;
       setTimeout(() => this._initMap(), 0);
     }
 
@@ -496,9 +509,14 @@ export default class GoogleMap extends Component {
       ...(this.props.apiKey && { key: this.props.apiKey }),
       ...this.props.bootstrapURLKeys,
     };
-
+    const libraries = {
+      visualization: this.props.heatmapLibrary,
+      geometry: this.props.geometryLibrary,
+      places: this.props.placesLibrary,
+      drawing: this.props.drawingLibrary,
+    };
     this.props
-      .googleMapLoader(bootstrapURLKeys, this.props.heatmapLibrary)
+      .googleMapLoader(bootstrapURLKeys, libraries)
       .then(maps => {
         if (!this.mounted_) {
           return;

--- a/src/loaders/google_map_loader.js
+++ b/src/loaders/google_map_loader.js
@@ -20,7 +20,7 @@ const _customPromise = new Promise(resolve => {
 });
 
 // TODO add libraries language and other map options
-export default (bootstrapURLKeys, heatmapLibrary) => {
+export default (bootstrapURLKeys, libraries) => {
   if (!$script_) {
     $script_ = require('scriptjs'); // eslint-disable-line
   }
@@ -71,10 +71,20 @@ export default (bootstrapURLKeys, heatmapLibrary) => {
     );
 
     const baseUrl = getUrl(bootstrapURLKeys.region);
-    const libraries = heatmapLibrary ? '&libraries=visualization' : '';
+    const librariesUrl = Object.keys(libraries)
+      .reduce(
+        (libraryUrl, libraryKey) => {
+          if (libraries[libraryKey]) {
+            return `${libraryUrl}${libraryKey},`;
+          }
+          return libraryUrl;
+        },
+        '&libraries='
+      )
+      .slice(0, -1);
 
     $script_(
-      `${baseUrl}${API_PATH}${params}${libraries}`,
+      `${baseUrl}${API_PATH}${params}${librariesUrl}`,
       () =>
         typeof window.google === 'undefined' &&
         reject(new Error('google map initialization error (not loaded)'))

--- a/src/loaders/google_map_loader.js
+++ b/src/loaders/google_map_loader.js
@@ -71,17 +71,19 @@ export default (bootstrapURLKeys, libraries) => {
     );
 
     const baseUrl = getUrl(bootstrapURLKeys.region);
-    const librariesUrl = Object.keys(libraries)
-      .reduce(
-        (libraryUrl, libraryKey) => {
-          if (libraries[libraryKey]) {
-            return `${libraryUrl}${libraryKey},`;
-          }
-          return libraryUrl;
-        },
-        '&libraries='
-      )
-      .slice(0, -1);
+    const librariesUrl = (Object.keys(libraries).some(e => libraries[e]) &&
+      Object.keys(libraries)
+        .reduce(
+          (libraryUrl, libraryKey) => {
+            if (libraries[libraryKey]) {
+              return `${libraryUrl}${libraryKey},`;
+            }
+            return libraryUrl;
+          },
+          '&libraries='
+        )
+        .slice(0, -1)) ||
+      '';
 
     $script_(
       `${baseUrl}${API_PATH}${params}${librariesUrl}`,


### PR DESCRIPTION
Possible fix for issue [673](https://github.com/google-map-react/google-map-react/issues/673):

Supports both the previous and current way of loading libraries:

**Previous way**:
```
<GoogleMapReact
          bootstrapURLKeys={{
            libraries: 'drawing',
            key: googleMapKey,
          }}
          yesIWantToUseGoogleMapApiInternals
          onGoogleApiLoaded={({ maps }) => {
            console.log(maps.drawing);
          }}
        />
```

**Current way**:
```
<GoogleMapReact
          bootstrapURLKeys={{
            key: googleMapKey,
          }}
          drawingLibrary
          yesIWantToUseGoogleMapApiInternals
          onGoogleApiLoaded={({ maps }) => {
            console.log(maps.drawing);
          }}
        />
```