### PR TITLE
Added React 16 createPortal with backwards compatibility

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -38,6 +38,11 @@ const DEFAULT_MIN_ZOOM = 3;
 // Starting with version 3.32, the maps API calls `draw()` each frame during
 // a zoom animation.
 const DRAW_CALLED_DURING_ANIMATION_VERSION = 32;
+const IS_REACT_16 = ReactDOM.createPortal !== undefined;
+
+const createPortal = IS_REACT_16
+  ? ReactDOM.createPortal
+  : ReactDOM.unstable_renderSubtreeIntoContainer;
 
 function defaultOptions_(/* maps */) {
   return {
@@ -240,7 +245,7 @@ export default class GoogleMap extends Component {
     this.zoomAnimationInProgress_ = false;
 
     this.state = {
-      overlayCreated: false,
+      overlay: null,
     };
   }
 
@@ -478,6 +483,23 @@ export default class GoogleMap extends Component {
     });
   };
 
+  _renderPortal = () => {
+    return (
+      <GoogleMapMarkers
+        experimental={this.props.experimental}
+        onChildClick={this._onChildClick}
+        onChildMouseDown={this._onChildMouseDown}
+        onChildMouseEnter={this._onChildMouseEnter}
+        onChildMouseLeave={this._onChildMouseLeave}
+        geoService={this.geoService_}
+        insideMapPanes
+        distanceToMouse={this.props.distanceToMouse}
+        getHoverDistance={this._getHoverDistance}
+        dispatcher={this.markersDispatcher_}
+      />
+    );
+  };
+
   _initMap = () => {
     // only initialize the map once
     if (this.initialized_) {
@@ -593,7 +615,6 @@ export default class GoogleMap extends Component {
               : '2000px';
 
             const div = document.createElement('div');
-            this.div = div;
             div.style.backgroundColor = 'transparent';
             div.style.position = 'absolute';
             div.style.left = '0px';
@@ -616,30 +637,26 @@ export default class GoogleMap extends Component {
               maps,
               overlay.getProjection()
             );
-            ReactDOM.unstable_renderSubtreeIntoContainer(
-              this_,
-              <GoogleMapMarkers
-                experimental={this_.props.experimental}
-                onChildClick={this_._onChildClick}
-                onChildMouseDown={this_._onChildMouseDown}
-                onChildMouseEnter={this_._onChildMouseEnter}
-                onChildMouseLeave={this_._onChildMouseLeave}
-                geoService={this_.geoService_}
-                insideMapPanes
-                distanceToMouse={this_.props.distanceToMouse}
-                getHoverDistance={this_._getHoverDistance}
-                dispatcher={this_.markersDispatcher_}
-              />,
-              div,
-              // remove prerendered markers
-              () => this_.setState({ overlayCreated: true })
-            );
+
+            if (!IS_REACT_16) {
+              createPortal(
+                this_,
+                this_._renderPortal(),
+                div,
+                // remove prerendered markers
+                () => this_.setState({ overlay: div })
+              );
+            } else {
+              this_.setState({ overlay: div });
+            }
           },
 
           onRemove() {
-            if (this.div) {
-              ReactDOM.unmountComponentAtNode(this.div);
+            const overlay = this_.state.overlay;
+            if (overlay && !IS_REACT_16) {
+              ReactDOM.unmountComponentAtNode(overlay);
             }
+            this_.setState({ overlay: null });
           },
 
           draw() {
@@ -1077,7 +1094,8 @@ export default class GoogleMap extends Component {
   };
 
   render() {
-    const mapMarkerPrerender = !this.state.overlayCreated
+    const overlay = this.state.overlay;
+    const mapMarkerPrerender = !overlay
       ? <GoogleMapMarkersPrerender
           experimental={this.props.experimental}
           onChildClick={this._onChildClick}
@@ -1100,6 +1118,7 @@ export default class GoogleMap extends Component {
         onClick={this._onMapClick}
       >
         <GoogleMapMap registerChild={this._registerChild} />
+        {IS_REACT_16 && overlay && createPortal(this._renderPortal(), overlay)}
 
         {/* render markers before map load done */}
         {mapMarkerPrerender}


### PR DESCRIPTION
Fixes #642 

Same as https://github.com/google-map-react/google-map-react/pull/647 but still works with React 15.

NOTE: no breaking changes here, could be released as a minor version.