### PR TITLE
Google Map loader respecting the app language change

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
   },
   "dependencies": {
     "@mapbox/point-geometry": "^0.1.0",
-    "eventemitter3": "^1.1.0",
-    "scriptjs": "^2.5.7"
+    "eventemitter3": "^1.1.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4989,10 +4989,6 @@ sax@^1.2.4, sax@~1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-scriptjs@^2.5.7:
-  version "2.5.8"
-  resolved "https://registry.yarnpkg.com/scriptjs/-/scriptjs-2.5.8.tgz#d0c43955c2e6bad33b6e4edf7b53b8965aa7ca5f"
-
 scss-tokenizer@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"


### PR DESCRIPTION
**Problem**: When map language is dependent on app settings, the map doesn't respects current language and region value passed in `bootstrapURLKeys` object. New loader handles  `bootstrapURLKeys` change and reloads the Google Maps API (because of lack support to change language in API).

You can try this new loader here: [https://codesandbox.io/s/pppvk1o9z0](https://codesandbox.io/s/pppvk1o9z0)