### PR TITLE
Fix: Update heatmap layer when heatmap positions prop changes

### DIFF
--- a/develop/GMap.js
+++ b/develop/GMap.js
@@ -18,6 +18,7 @@ import GoogleMapReact from '../src';
 
 import ptInBounds from './utils/ptInBounds';
 import withStateSelector from './utils/withStateSelector';
+import { GOOGLE_API_KEY } from './config/Google_API_key';
 
 export const gMap = (
   {
@@ -34,7 +35,7 @@ export const gMap = (
 ) => (
   <GoogleMapReact
     bootstrapURLKeys={{
-      key: 'AIzaSyBMqz4ueWMfGGqdXlvwE_cIVfar60GROi8',
+      key: GOOGLE_API_KEY,
     }}
     style={style}
     options={options}

--- a/develop/GMapHeatmap.js
+++ b/develop/GMapHeatmap.js
@@ -11,7 +11,12 @@ import {
 } from 'recompose';
 import { createSelector } from 'reselect';
 
-import { susolvkaCoords, generateMarkers, heatmapData } from './data/fakeData';
+import {
+  susolvkaCoords,
+  generateMarkers,
+  heatmapData,
+  generateHeatmapData,
+} from './data/fakeData';
 
 import GoogleMapReact from '../src';
 import SimpleMarker from './markers/SimpleMarker';
@@ -19,12 +24,14 @@ import SimpleMarker from './markers/SimpleMarker';
 import ptInBounds from './utils/ptInBounds';
 import withStateSelector from './utils/withStateSelector';
 import { GOOGLE_API_KEY } from './config/Google_API_key';
+import withSafeInterval from './utils/withSafeInterval';
 
 export const gMapHeatmap = (
   {
     style,
     hoverDistance,
     options,
+    heatmap,
     mapParams: { center, zoom },
     onChange,
     onChildMouseEnter,
@@ -46,7 +53,7 @@ export const gMapHeatmap = (
     onChange={onChange}
     onChildMouseEnter={onChildMouseEnter}
     onChildMouseLeave={onChildMouseLeave}
-    heatmap={heatmapData}
+    heatmap={heatmap}
     heatmapLibrary
   >
     {markers}
@@ -77,11 +84,22 @@ export const gMapHOC = compose(
     )),
   withState('hoveredMarkerId', 'setHoveredMarkerId', -1),
   withState('mapParams', 'setMapParams', { center: susolvkaCoords, zoom: 6 }),
+  withSafeInterval,
+  withState('heatmap', 'setHeatmap', heatmapData),
   // describe events
   withHandlers({
-    onChange: ({ setMapParams }) =>
+    onChange: ({ setMapParams, setSafeInterval, setHeatmap, mapParams }) =>
       ({ center, zoom, bounds }) => {
         setMapParams({ center, zoom, bounds });
+        const boundSetHeatmap = setHeatmap.bind(this);
+        setSafeInterval(
+          () => {
+            boundSetHeatmap(
+              generateHeatmapData(mapParams.center.lat, mapParams.center.lng)
+            );
+          },
+          3000
+        );
       },
     onChildMouseEnter: ({ setHoveredMarkerId }) =>
       (hoverKey, { id }) => {

--- a/develop/GMapHeatmap.js
+++ b/develop/GMapHeatmap.js
@@ -18,6 +18,7 @@ import SimpleMarker from './markers/SimpleMarker';
 
 import ptInBounds from './utils/ptInBounds';
 import withStateSelector from './utils/withStateSelector';
+import { GOOGLE_API_KEY } from './config/Google_API_key';
 
 export const gMapHeatmap = (
   {
@@ -34,7 +35,7 @@ export const gMapHeatmap = (
 ) => (
   <GoogleMapReact
     bootstrapURLKeys={{
-      key: 'AIzaSyBMqz4ueWMfGGqdXlvwE_cIVfar60GROi8',
+      key: GOOGLE_API_KEY,
     }}
     style={style}
     options={options}

--- a/develop/GMapLayers.js
+++ b/develop/GMapLayers.js
@@ -18,6 +18,7 @@ import SimpleMarker from './markers/SimpleMarker';
 
 import ptInBounds from './utils/ptInBounds';
 import withStateSelector from './utils/withStateSelector';
+import { GOOGLE_API_KEY } from './config/Google_API_key';
 
 export const gMap = (
   {
@@ -34,7 +35,7 @@ export const gMap = (
 ) => (
   <GoogleMapReact
     bootstrapURLKeys={{
-      key: 'AIzaSyBMqz4ueWMfGGqdXlvwE_cIVfar60GROi8',
+      key: GOOGLE_API_KEY,
     }}
     style={style}
     options={options}

--- a/develop/GMapOptim.js
+++ b/develop/GMapOptim.js
@@ -24,6 +24,7 @@ import ReactiveMarker from './markers/ReactiveMarker';
 import ptInBounds from './utils/ptInBounds';
 import props2Stream from './utils/props2Stream';
 import withStateSelector from './utils/withStateSelector';
+import { GOOGLE_API_KEY } from './config/Google_API_key';
 
 export const gMap = (
   {
@@ -40,7 +41,7 @@ export const gMap = (
 ) => (
   <GoogleMapReact
     bootstrapURLKeys={{
-      key: 'AIzaSyBMqz4ueWMfGGqdXlvwE_cIVfar60GROi8',
+      key: GOOGLE_API_KEY,
     }}
     style={style}
     options={options}

--- a/develop/GMapResizable.js
+++ b/develop/GMapResizable.js
@@ -19,6 +19,7 @@ import SimpleMarker from './markers/SimpleMarker';
 
 import ptInBounds from './utils/ptInBounds';
 import withStateSelector from './utils/withStateSelector';
+import { GOOGLE_API_KEY } from './config/Google_API_key';
 
 export const gMapResizable = (
   {
@@ -35,7 +36,7 @@ export const gMapResizable = (
 ) => (
   <GoogleMapReact
     bootstrapURLKeys={{
-      key: 'AIzaSyBMqz4ueWMfGGqdXlvwE_cIVfar60GROi8',
+      key: GOOGLE_API_KEY,
     }}
     style={style}
     options={options}

--- a/develop/config/Google_API_key.js
+++ b/develop/config/Google_API_key.js
@@ -1,0 +1,1 @@
+export const GOOGLE_API_KEY = '';

--- a/develop/config/Google_API_key.js
+++ b/develop/config/Google_API_key.js
@@ -1,1 +1,2 @@
+// use your own google maps API key with localhost permissions below
 export const GOOGLE_API_KEY = '';

--- a/develop/data/fakeData.js
+++ b/develop/data/fakeData.js
@@ -20,6 +20,26 @@ export const generateMarkers = count =>
       Math.sin(5 * index / 180),
   }));
 
+function getRandomNumberBetween(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+export const generateHeatmapData = (lat, lng) => {
+  const newFakeReadings = x => {
+    const newReadings = [];
+
+    for (let i = 0; i <= x; i++) {
+      newReadings.push({
+        weight: getRandomNumberBetween(0.1, 4),
+        lat: getRandomNumberBetween(lat - 1, lat + 1),
+        lng: getRandomNumberBetween(lng - 1, lng + 1),
+      });
+    }
+    return newReadings;
+  };
+  return newFakeReadings(10);
+};
+
 export const heatmapData = {
   positions: [
     {

--- a/develop/data/fakeData.js
+++ b/develop/data/fakeData.js
@@ -20,26 +20,6 @@ export const generateMarkers = count =>
       Math.sin(5 * index / 180),
   }));
 
-function getRandomNumberBetween(min, max) {
-  return Math.random() * (max - min) + min;
-}
-
-export const generateHeatmapData = (lat, lng) => {
-  const newFakeReadings = x => {
-    const newReadings = [];
-
-    for (let i = 0; i <= x; i++) {
-      newReadings.push({
-        weight: getRandomNumberBetween(0.1, 4),
-        lat: getRandomNumberBetween(lat - 1, lat + 1),
-        lng: getRandomNumberBetween(lng - 1, lng + 1),
-      });
-    }
-    return newReadings;
-  };
-  return newFakeReadings(10);
-};
-
 export const heatmapData = {
   positions: [
     {
@@ -67,4 +47,27 @@ export const heatmapData = {
     radius: 20,
     opacity: 0.7,
   },
+};
+
+function getRandomNumberBetween(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+export const generateHeatmapData = (lat, lng) => {
+  const newFakeReadings = x => {
+    const newReadings = [];
+
+    for (let i = 0; i <= x; i++) {
+      newReadings.push({
+        weight: getRandomNumberBetween(0.1, 4),
+        lat: getRandomNumberBetween(lat - 1, lat + 1),
+        lng: getRandomNumberBetween(lng - 1, lng + 1),
+      });
+    }
+    return newReadings;
+  };
+  return {
+    positions: newFakeReadings(10),
+    options: heatmapData.options,
+  };
 };

--- a/develop/utils/withSafeInterval.js
+++ b/develop/utils/withSafeInterval.js
@@ -1,0 +1,48 @@
+import { createElement, Component } from 'react';
+
+const safeTimerFactory = (setFn, clearFn, propName, hocName) =>
+  Target => {
+    class SafeTimer extends Component {
+      constructor(props, context) {
+        super(props, context);
+
+        this.unsubscribers = [];
+        this[propName] = this[propName].bind(this);
+      }
+
+      componentWillUnmount() {
+        this.unsubscribers.forEach(unsubscribe => unsubscribe());
+
+        this.unsubscribers = [];
+      }
+
+      [propName](...args) {
+        const id = setFn(...args);
+        const unsubscriber = () => clearFn(id);
+
+        this.unsubscribers.push(unsubscriber);
+
+        return unsubscriber;
+      }
+
+      render() {
+        return createElement(Target, {
+          ...this.props,
+          [propName]: this[propName],
+        });
+      }
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      SafeTimer.displayName = `${hocName}`;
+    }
+
+    return SafeTimer;
+  };
+
+export default safeTimerFactory(
+  global.setInterval,
+  global.clearInterval,
+  'setSafeInterval',
+  'withSafeInterval'
+);

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -384,6 +384,18 @@ export default class GoogleMap extends Component {
         });
         this._setLayers(nextProps.layerTypes);
       }
+
+      if (
+        this.heatmap &&
+        !shallowEqual(nextProps.heatmap.positions, this.props.heatmap.positions)
+      ) {
+        this.heatmap.setData(
+          nextProps.heatmap.positions.map(p => ({
+            location: new this.maps_.LatLng(p.lat, p.lng),
+            weight: p.weight,
+          }))
+        );
+      }
     }
   }
 


### PR DESCRIPTION
This PR is somewhere between a bug fix and a new feature.

Before this PR, if the heatmap positions prop was updated, the new data would not be displayed on the heatmap layer.
After this PR, if the heatmap.positions data is changed, then the heatmap layer will run a setData call and update the heatmap accordingly.
To demonstrate this, I updated the develop/GMapHeatmap.js example with a random data generator.

Along the way, I changed how the API key is set in the develop/ examples. I am happy to remove that change, but I think it's better this way. Additionally, I noticed that the API key in the develop folder doesn't work currently.