### PR TITLE
Fix isomorphic rendering

### DIFF
--- a/src/loaders/google_map_loader.js
+++ b/src/loaders/google_map_loader.js
@@ -23,8 +23,10 @@ const destroyOldGoogleMapsInstance = url => {
 };
 
 // Callback for the Google Maps API src
-window.googleMapsAPILoadedPromise = () =>
-  window.dispatchEvent(new CustomEvent(EVENT_GMAPS_LOADED));
+if (typeof window !== 'undefined') {
+  window.googleMapsAPILoadedPromise = () =>
+    window.dispatchEvent(new CustomEvent(EVENT_GMAPS_LOADED));
+}
 
 const getScriptUrl = bootstrapURLKeys => {
   const baseUrl = getBaseUrl(bootstrapURLKeys.region);


### PR DESCRIPTION
On the server, `window` is undefined. Importing this file (which is done when just `import`ing google-map-react) sets a callback on `window` (undefined), crashing the server.