### PR TITLE
Pass zoom value to zoom animation callbacks

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -715,7 +715,7 @@ export default class GoogleMap extends Component {
           if (this_.geoService_.getZoom() !== map.getZoom()) {
             if (!this_.zoomAnimationInProgress_) {
               this_.zoomAnimationInProgress_ = true;
-              this_._onZoomAnimationStart();
+              this_._onZoomAnimationStart(map.zoom);
             }
 
             // If draw() is not called each frame during a zoom animation,
@@ -762,7 +762,7 @@ export default class GoogleMap extends Component {
 
           if (this_.zoomAnimationInProgress_) {
             this_.zoomAnimationInProgress_ = false;
-            this_._onZoomAnimationEnd();
+            this_._onZoomAnimationEnd(map.zoom);
           }
 
           this_.updateCounter_++;


### PR DESCRIPTION
Pretty minor quibble, but it would be helpful to get the map's new zoom level returned on the zoom animation callbacks. 
Especially since they are already set up to pass params to the callback prop, but nothing is passed. 