### PR TITLE
Add prop 'onDragEnd'

### DIFF
--- a/API.md
+++ b/API.md
@@ -128,6 +128,9 @@ Default: false
 
 #### onDrag ((map) => void)
 
+#### onDragEnd ((map) => void)
+When the map stops moving after the user drags. Takes into account drag inertia.
+
 #### onZoomAnimationEnd (func)
 
 #### onMapTypeIdChange (func)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Add prop `onDragEnd` to react on the `dragend` event
+
 Add [google-map-clustering-example](https://github.com/istarkov/google-map-clustering-example)
 
 Add prop `onTilesLoaded` to react on the `tilesloaded` event

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -123,6 +123,7 @@ export default class GoogleMap extends Component {
     onZoomAnimationStart: PropTypes.func,
     onZoomAnimationEnd: PropTypes.func,
     onDrag: PropTypes.func,
+    onDragEnd: PropTypes.func,
     onMapTypeIdChange: PropTypes.func,
     onTilesLoaded: PropTypes.func,
     options: PropTypes.any,
@@ -799,6 +800,15 @@ export default class GoogleMap extends Component {
           this_.dragTime_ = new Date().getTime();
           this_._onDrag(map);
         });
+
+        maps.event.addListener(map, 'dragend', () => {
+          // 'dragend' fires on mouse release.
+          // 'idle' listener waits until drag inertia ends before firing `onDragEnd`
+          const idleListener = maps.event.addListener(map, 'idle', () => {
+            maps.event.removeListener(idleListener);
+            this_._onDragEnd(map);
+          });
+        });
         // user choosing satellite vs roads, etc
         maps.event.addListener(map, 'maptypeid_changed', () => {
           this_._onMapTypeIdChange(map.getMapTypeId());
@@ -834,6 +844,9 @@ export default class GoogleMap extends Component {
   _getHoverDistance = () => this.props.hoverDistance;
 
   _onDrag = (...args) => this.props.onDrag && this.props.onDrag(...args);
+
+  _onDragEnd = (...args) =>
+    this.props.onDragEnd && this.props.onDragEnd(...args);
 
   _onMapTypeIdChange = (...args) =>
     this.props.onMapTypeIdChange && this.props.onMapTypeIdChange(...args);


### PR DESCRIPTION
There is no callback dragEnd, which I feel would be a helpful callback to have.

The `dragEnd` event fired by the maps API fires as soon as the user releases the mouse, while the map inertia continues to pan the map. This callback therefore waits until the `idle` event is fired, then cleans up the event listener and invokes `props.dragEnd`

Please let me know if there's a better way to do this!