### PR TITLE
Change yesIWantToUseGoogleMapApiInternals

### DIFF
--- a/API.md
+++ b/API.md
@@ -147,11 +147,11 @@ This function is called when the visible tiles have finished loading.
 <GoogleMap  onGoogleApiLoaded={({map, maps}) => console.log(map, maps)} />
 ```
 
-To prevent warning message add _yesIWantToUseGoogleMapApiInternals_ property to GoogleMap
+To prevent warning message add _useGoogleMapApiInternals_ property to GoogleMap
 
 ```javascript
 <GoogleMap  onGoogleApiLoaded={({map, maps}) => console.log(map, maps)}
-                       yesIWantToUseGoogleMapApiInternals
+                       useGoogleMapApiInternals
  />
  ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ Add ability to access to internal google api
 <GoogleMap  onGoogleApiLoaded={({map, maps}) => console.log(map, maps)} />
 ```
 
-(*to prevent warn message add _yesIWantToUseGoogleMapApiInternals_ property to GoogleMap*)
+(*to prevent warn message add _useGoogleMapApiInternals_ property to GoogleMap*)
 
 
 ###Sun Oct 4 2015

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ It renders components on the map before (and even without) the Google Maps API l
 
 There is no need to place a `<script src=` tag at top of page. The Google Maps API loads upon the first usage of the `GoogleMapReact` component.
 
-### Use Google Maps API 
+### Use Google Maps API
 
-You can access to Google Maps `map` and `maps` objects by using `onGoogleApiLoaded`, in this case you will need to set `yesIWantToUseGoogleMapApiInternals` to `true`
+You can access to Google Maps `map` and `maps` objects by using `onGoogleApiLoaded`, in this case you will need to set `useGoogleMapApiInternals` to `true`
 
 ```javascript
 ...
@@ -100,7 +100,7 @@ const handleApiLoaded = (map, maps) => {
   bootstrapURLKeys={{ key: /* YOUR KEY HERE */ }}
   defaultCenter={this.props.center}
   defaultZoom={this.props.zoom}
-  yesIWantToUseGoogleMapApiInternals
+  useGoogleMapApiInternals
   onGoogleApiLoaded={({ map, maps }) => handleApiLoaded(map, maps)}
 >
   <AnyReactComponent
@@ -111,7 +111,7 @@ const handleApiLoaded = (map, maps) => {
 </GoogleMapReact>
 ```
 
-PST: Remember to set `yesIWantToUseGoogleMapApiInternals` to true.
+PST: Remember to set `useGoogleMapApiInternals` to true.
 
 [Example here](https://github.com/google-map-react/google-map-react-examples/blob/master/src/examples/Main.js#L69)
 

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -132,7 +132,7 @@ export default class GoogleMap extends Component {
     margin: PropTypes.array,
     googleMapLoader: PropTypes.any,
     onGoogleApiLoaded: PropTypes.func,
-    yesIWantToUseGoogleMapApiInternals: PropTypes.bool,
+    useGoogleMapApiInternals: PropTypes.bool,
     draggable: PropTypes.bool,
     style: PropTypes.any,
     resetBoundsOnResize: PropTypes.bool,
@@ -150,7 +150,7 @@ export default class GoogleMap extends Component {
     debounced: true,
     options: defaultOptions_,
     googleMapLoader,
-    yesIWantToUseGoogleMapApiInternals: false,
+    useGoogleMapApiInternals: false,
     style: {
       width: '100%',
       height: '100%',
@@ -816,13 +816,13 @@ export default class GoogleMap extends Component {
     if (this.props.onGoogleApiLoaded) {
       if (
         process.env.NODE_ENV !== 'production' &&
-        this.props.yesIWantToUseGoogleMapApiInternals !== true
+        this.props.useGoogleMapApiInternals !== true
       ) {
         console.warn(
           'GoogleMap: ' + // eslint-disable-line
             'Usage of internal api objects is dangerous ' +
             'and can cause a lot of issues.\n' +
-            'To hide this warning add yesIWantToUseGoogleMapApiInternals={true} ' +
+            'To hide this warning add useGoogleMapApiInternals={true} ' +
             'to <GoogleMap instance'
         );
       }


### PR DESCRIPTION
I think `yesIWantToUseGoogleMapApiInternals` variable name is long enough, and we should stick to what makes more sense to the whole community. `useGoogleMapApiInternals` is more understandable as a boolean. Let me know what you think.

Other than that, really cool package 🙂