### PR TITLE
Add UNSAFE_ prefix to deprecated lifecycle methods

### DIFF
--- a/develop/utils/props2Stream.js
+++ b/develop/utils/props2Stream.js
@@ -15,7 +15,7 @@ const prop2Stream = (propName, comparator = (a, b) => a === b) =>
         comparator
       );
 
-      componentWillReceiveProps(nextProps) {
+      UNSAFE_componentWillReceiveProps(nextProps) {
         this.props$.next(nextProps[propName]);
       }
 

--- a/develop/utils/stream2Props.js
+++ b/develop/utils/stream2Props.js
@@ -10,7 +10,7 @@ const stream2Props = props2Stream =>
     return class extends Component {
       state = {};
 
-      componentWillMount() {
+      UNSAFE_componentWillMount() {
         this.subscription = props2Stream(this.props).subscribe(value =>
           this.setState({ value }));
       }

--- a/develop/utils/withStateSelector.js
+++ b/develop/utils/withStateSelector.js
@@ -21,7 +21,7 @@ const withStateSelector = (stateName, stateUpdaterName, selectorFactory) =>
           callback
         );
 
-      componentWillReceiveProps(nextProps) {
+      UNSAFE_componentWillReceiveProps(nextProps) {
         // reselect memoize result
         const nextStateValue = this.selector(nextProps);
         if (nextStateValue !== this.state.stateValue) {

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -266,7 +266,8 @@ export default class GoogleMap extends Component {
       );
     }
 
-    addPassiveEventListener(window, 'mouseup', this._onChildMouseUp, false);    const bootstrapURLKeys = {
+    addPassiveEventListener(window, 'mouseup', this._onChildMouseUp, false);
+    const bootstrapURLKeys = {
       ...(this.props.apiKey && { key: this.props.apiKey }),
       ...this.props.bootstrapURLKeys,
     };

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -266,8 +266,7 @@ export default class GoogleMap extends Component {
       );
     }
 
-    addPassiveEventListener(window, 'mouseup', this._onChildMouseUp, false);
-    const bootstrapURLKeys = {
+    addPassiveEventListener(window, 'mouseup', this._onChildMouseUp, false);    const bootstrapURLKeys = {
       ...(this.props.apiKey && { key: this.props.apiKey }),
       ...this.props.bootstrapURLKeys,
     };
@@ -293,7 +292,7 @@ export default class GoogleMap extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     if (process.env.NODE_ENV !== 'production') {
       if (!shallowEqual(this.props.defaultCenter, nextProps.defaultCenter)) {
         console.warn(


### PR DESCRIPTION
Projects using google-map-react as a dependency show console warnings about soon-to-be-deprecated lifecycle methods. React 17 will continue support for methods with the UNSAFE_ prefix, but not for unprefixed methods.