### PR TITLE
Fixed issue with `undefined` initial zoom

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -344,12 +344,10 @@ export default class GoogleMap extends Component {
           }
         }
       }
-
-      if (!isEmpty(nextProps.zoom)) {
-        // if zoom chaged by user
-        if (Math.abs(nextProps.zoom - this.props.zoom) > 0) {
-          this.map_.setZoom(nextProps.zoom);
-        }
+      
+      // if zoom chaged by user
+      if (!isEmpty(nextProps.zoom) && this.props.zoom !== nextProps.zoom) {
+        this.map_.setZoom(nextProps.zoom);
       }
 
       if (!isEmpty(this.props.draggable) && isEmpty(nextProps.draggable)) {


### PR DESCRIPTION
Resolved Issue: 
mount zoom value is not set, in process of work we set zoom to any value (eg. 12). 

`Math.abs(nextProps.zoom - this.props.zoom) > 0` condition is always `false`

`Math.abs(12 - undefined)` = `NaN`