### PR TITLE
Updated China base url

### DIFF
--- a/src/loaders/google_map_loader.js
+++ b/src/loaders/google_map_loader.js
@@ -2,13 +2,6 @@ const BASE_URL = 'https://maps';
 const DEFAULT_URL = `${BASE_URL}.googleapis.com`;
 const API_PATH = '/maps/api/js?callback=_$_google_map_initialize_$_';
 
-const getUrl = region => {
-  if (region && region.toLowerCase() === 'cn') {
-    return `${BASE_URL}.google.cn`;
-  }
-  return DEFAULT_URL;
-};
-
 let $script_ = null;
 
 let loadPromise_;
@@ -70,11 +63,10 @@ export default (bootstrapURLKeys, heatmapLibrary) => {
       ''
     );
 
-    const baseUrl = getUrl(bootstrapURLKeys.region);
     const libraries = heatmapLibrary ? '&libraries=visualization' : '';
 
     $script_(
-      `${baseUrl}${API_PATH}${params}${libraries}`,
+      `${DEFAULT_URL}${API_PATH}${params}${libraries}`,
       () =>
         typeof window.google === 'undefined' &&
         reject(new Error('google map initialization error (not loaded)'))


### PR DESCRIPTION
Starting February 3, 2020, Google Maps Platform APIs will no longer be hosted from the google.cn domain. All requests to load Google Maps Platform APIs from the google.cn domain will return an error.