### PR TITLE
On resize it's getting undefined minZoom

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -756,7 +756,7 @@ export default class GoogleMap extends Component {
           if (this.resetSizeOnIdle_) {
             this._setViewSize();
             const currMinZoom = this._computeMinZoom(
-              this.props.options.minZoom
+              options.minZoom
             );
 
             if (currMinZoom !== this.minZoom_) {

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -755,9 +755,7 @@ export default class GoogleMap extends Component {
         maps.event.addListener(map, 'idle', () => {
           if (this.resetSizeOnIdle_) {
             this._setViewSize();
-            const currMinZoom = this._computeMinZoom(
-              options.minZoom
-            );
+            const currMinZoom = this._computeMinZoom(options.minZoom);
 
             if (currMinZoom !== this.minZoom_) {
               this.minZoom_ = currMinZoom;


### PR DESCRIPTION
`this.props.options.minZoom` is not getting the value that's been passed (on window resize), instead getting `undefined` setting the minZoom level to default 3... should actually be `options.minZoom`