### PR TITLE
Moves GoogleMapMarkers MarkerDispatcher binds to componentDidMount

### DIFF
--- a/src/google_map_markers.js
+++ b/src/google_map_markers.js
@@ -48,13 +48,6 @@ export default class GoogleMapMarkers extends Component {
 
   constructor(props) {
     super(props);
-    this.props.dispatcher.on('kON_CHANGE', this._onChangeHandler);
-    this.props.dispatcher.on(
-      'kON_MOUSE_POSITION_CHANGE',
-      this._onMouseChangeHandler
-    );
-    this.props.dispatcher.on('kON_CLICK', this._onChildClick);
-    this.props.dispatcher.on('kON_MDOWN', this._onChildMouseDown);
 
     this.dimensionsCache_ = {};
     this.hoverKey_ = null;
@@ -62,6 +55,16 @@ export default class GoogleMapMarkers extends Component {
     this.allowMouse_ = true;
 
     this.state = { ...this._getState(), hoverKey: null };
+  }
+
+  componentDidMount() {
+    this.props.dispatcher.on('kON_CHANGE', this._onChangeHandler);
+    this.props.dispatcher.on(
+      'kON_MOUSE_POSITION_CHANGE',
+      this._onMouseChangeHandler
+    );
+    this.props.dispatcher.on('kON_CLICK', this._onChildClick);
+    this.props.dispatcher.on('kON_MDOWN', this._onChildMouseDown);
   }
 
   shouldComponentUpdate(nextProps, nextState) {


### PR DESCRIPTION
Resolves #843 
This should also negate the need to merge [this PR](https://github.com/google-map-react/google-map-react/pull/849)

The issue above was caused because the `pt` argument in `distanceToMouse` was undefined. Tracing backwards I found out that value corresponded to the `this.dimensionsCache_[childKey]` value in `GoogleMapMarkers`, which when an erroring, was an empty object.

![console logged values when erroring](https://imgur.com/EAa5aHFl.png)

Instead of inserting an empty object check into  `_onChangeHandler` in `GoogleMapMarkers` or overriding the `distanceToMouse` function on the child component, I went ahead and moved the `MarkerDispatcher` binds for `GoogleMapMarkers` into `componentDidMount`.

Previously, those binds were done in the constructor causing `dimensionsCache_` to be the default value (an empty object) instead of the updated value set inside of the `GoogleMapMarkers.render` function.

This change ensures that the `this.dimensionsCache_[childKey]` is defined when called in `_onChangeHandler` and thus the `pt` value is defined in the subsequent `distanceToMouse` call.
