### PR TITLE
Fix key not being set in bootstrapURLKeys

### DIFF
--- a/src/loaders/google_map_loader.js
+++ b/src/loaders/google_map_loader.js
@@ -51,7 +51,14 @@ export default (bootstrapURLKeys, heatmapLibrary) => {
   }
 
   if (!loader_) {
-    loader_ = new Loader({ ...bootstrapURLKeys, libraries });
+    const { key, ...restKeys } = bootstrapURLKeys;
+
+    loader_ = new Loader({
+      // need to keep key for backwards compatibility
+      apiKey: key || '',
+      ...restKeys,
+      libraries,
+    });
   }
 
   const loadPromise = loader_.load().then(() => {


### PR DESCRIPTION
Fixes #947 

Key was not being set properly because [@google-maps/js-api-loader](https://github.com/googlemaps/js-api-loader) uses `apiKey` instead of `key` as a parameter.

Introduced in #942 