### PR TITLE
Fix #954: Use single instance of Loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "dependencies": {
-    "@googlemaps/js-api-loader": "^1.4.0",
+    "@googlemaps/js-api-loader": "^1.7.0",
     "@mapbox/point-geometry": "^0.1.0",
     "eventemitter3": "^4.0.4",
     "prop-types": "^15.7.2"
@@ -50,8 +50,8 @@
     "eslint-plugin-react": "^7.17.0",
     "eslint-plugin-standard": "^4.0.1",
     "expect": "1.20.2",
-    "jsdom": "^6.5.1",
     "gh-pages": "^2.2.0",
+    "jsdom": "^6.5.1",
     "microbundle-crl": "^0.13.10",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.4",

--- a/src/loaders/google_map_loader.js
+++ b/src/loaders/google_map_loader.js
@@ -1,5 +1,6 @@
 import { Loader } from '@googlemaps/js-api-loader';
 
+let loader_;
 let loadPromise_;
 let resolveCustomPromise_;
 
@@ -56,12 +57,15 @@ export default (bootstrapURLKeys, heatmapLibrary) => {
 
   const { key, ...restKeys } = bootstrapURLKeys;
 
-  const loader_ = new Loader({
-    // need to keep key for backwards compatibility
-    apiKey: key || '',
-    ...restKeys,
-    libraries,
-  });
+  // use single instance of Loader to avoid multiple api loads
+  if (!loader_) {
+    loader_ = new Loader({
+      // need to keep key as a prop for backwards compatibility
+      apiKey: key || '',
+      ...restKeys,
+      libraries,
+    });
+  }
 
   loadPromise_ = loader_.load().then(() => {
     resolveCustomPromise_(window.google.maps);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1199,10 +1199,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@googlemaps/js-api-loader@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-1.4.0.tgz#2dcfc22c25fb295596046c3120d870de686aae77"
-  integrity sha512-WVGfV0AINBFdpBt+qgtQe2H2KWDpH0snXTeIZID2YgGo5bSNKxjaFqiw96Ma19oupTWr9B1ud+6j4xhHe/BMWA==
+"@googlemaps/js-api-loader@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-1.7.0.tgz#d134f4a1bb8d1d864a5da41329da67b192acfa6b"
+  integrity sha512-6DkHnfFh81qcez8j8CEG8C3ANvA+3dbOzo8Hg9/DuNI78h36ILquUUuwUG6JHiRvPbqBG146rLDFSympUuO+6Q==
 
 "@hapi/address@2.x.x":
   version "2.1.4"


### PR DESCRIPTION
- Use single instance of Loader to avoid multiple api calls
- Update @googlemaps/js-api-loader to `1.7.0` that also takes care of this on their end