### PR TITLE
fix: sometimes changes to the draggable prop don't get propagated

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -302,12 +302,9 @@ class GoogleMap extends Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
-    // draggable does not affect inner components
     return (
-      !shallowEqual(
-        omit(this.props, ['draggable']),
-        omit(nextProps, ['draggable'])
-      ) || !shallowEqual(this.state, nextState)
+      !shallowEqual(this.props, nextProps) ||
+      !shallowEqual(this.state, nextState)
     );
   }
 


### PR DESCRIPTION
This pull request fixes an issue where a change to the draggable prop would not make the map draggable by not omitting the prop inside the `shouldComponentUpdate` prop.

If we change the prop but there is no other prop change the map behavior won't get updated, as that is done inside the `componentDidUpdate` function.

You can see the issue reproduced in this sandbox: https://codesandbox.io/s/distracted-wright-hrs51?file=/src/App.js

When you make the map draggable only the last map becomes draggable as there is another prop change, while the first 2 can't be dragged (the second one is expected as the code in `componentDidUpdate` omits those).

Fixes #978