### PR TITLE
add example linking to react-table search

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Now every object on the map can be hovered (however, you can still use css hover
 * local develop example (new)
 [develop example](./develop)
 
+* simple example linked to a react-table [open-mic-nights](https://apuchitnis.github.io/open-mic-nights), [source](https://github.com/apuchitnis/open-mic-nights)
+
 ## Documentation
 
 You can find the documentation here:


### PR DESCRIPTION
I really love google-map-react, and thought I'd share a link to my project that uses it and react-table, to help comedians find comedy nights to perform at. 

The interesting thing I've done is link the elements in the table to those shown on the map. So you can search in the table and the map updates.