### PR TITLE
Add support for mapId option.

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -388,6 +388,14 @@ class GoogleMap extends Component {
         // remove zoom, center and draggable options as these are managed by google-maps-react
         options = omit(options, ['zoom', 'center', 'draggable']);
 
+        // A Map's styles property cannot be set when a mapId is present. 
+        // When a mapId is present Map styles are controlled via the cloud console. 
+        if ('mapId' in options) {
+          options = omit(options, ['styles']);
+        }
+
+        console.log('options', options);
+
         if ('minZoom' in options) {
           const minZoom = this._computeMinZoom(options.minZoom);
           options.minZoom = _checkMinZoom(options.minZoom, minZoom);
@@ -585,7 +593,7 @@ class GoogleMap extends Component {
         // "MaxZoomStatus", "StreetViewStatus", "TransitMode", "TransitRoutePreference",
         // "TravelMode", "UnitSystem"
         const mapPlainObjects = pick(maps, isPlainObject);
-        const options =
+        let options =
           typeof this.props.options === 'function'
             ? this.props.options(mapPlainObjects)
             : this.props.options;
@@ -597,6 +605,12 @@ class GoogleMap extends Component {
 
         const minZoom = this._computeMinZoom(options.minZoom);
         this.minZoom_ = minZoom;
+
+        // A Map's styles property cannot be set when a mapId is present. 
+        // When a mapId is present Map styles are controlled via the cloud console. 
+        if ('mapId' in options) {
+          options = omit(options, ['styles']);
+        }
 
         const preMapOptions = {
           ...defaultOptions,


### PR DESCRIPTION
## Description

This PR adds support for mapId.  By default `mapId` works by adding to the options prop, but we get a warning in the console. This resolves said warning by removing the styles property from the maps option.

I've updated the type defs in the DefinitelyTyped repo as well ([PR here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/58072))

```
A Map's styles property cannot be set when a mapId is present.  When a mapId is present Map styles are controlled via the cloud console. Please see documentation at https://developers.google.com/maps/documentation/javascript/styling#cloud_tooling
```
