### PR TITLE
refactor: update @googlemaps/js-api-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "deploy": "gh-pages -d example/build"
   },
   "dependencies": {
-    "@googlemaps/js-api-loader": "^1.7.0",
+    "@googlemaps/js-api-loader": "^1.13.8",
     "@mapbox/point-geometry": "^0.1.0",
     "eventemitter3": "^4.0.4",
     "prop-types": "^15.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1199,10 +1199,12 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@googlemaps/js-api-loader@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-1.7.0.tgz#d134f4a1bb8d1d864a5da41329da67b192acfa6b"
-  integrity sha512-6DkHnfFh81qcez8j8CEG8C3ANvA+3dbOzo8Hg9/DuNI78h36ILquUUuwUG6JHiRvPbqBG146rLDFSympUuO+6Q==
+"@googlemaps/js-api-loader@^1.13.8":
+  version "1.13.8"
+  resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-1.13.8.tgz#9edfa766367dc145eec6a5ee6e90ba67244a4afb"
+  integrity sha512-xsn4vmrRc/p8PW6p6PglfInGiW9haEgkAeby4BGxNkVipWy8q0Wv16+sWpQ3rP31RahfWBoyVgAc1DgLXcZY3Q==
+  dependencies:
+    fast-deep-equal "^3.1.3"
 
 "@hapi/address@2.x.x":
   version "2.1.4"
@@ -4832,7 +4834,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==


### PR DESCRIPTION
There are some nice changes since 1.7.0:

- googlemaps/js-api-loader#99 -- retries loading the Google Maps script
  (which is a common source of error reports)
- googlemaps/js-api-loader#351 -- fixes bad promise rejection that was
  reported by a user of google-maps-react

It's a fairly big version bump but the vast majority of changes are dev
dependency bumps.