### PR TITLE
Re-center map if new center property value equals to previous one, but map was re-positioned manually

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -343,20 +343,14 @@ class GoogleMap extends Component {
 
         if (
           !prevCenter ||
-          Math.abs(currentCenter.lat - prevCenter.lat) +
-            Math.abs(currentCenter.lng - prevCenter.lng) >
+          Math.abs(currentCenter.lat - centerLatLng.lat) +
+            Math.abs(currentCenter.lng - centerLatLng.lng) >
             kEPS
         ) {
-          if (
-            Math.abs(currentCenter.lat - centerLatLng.lat) +
-              Math.abs(currentCenter.lng - centerLatLng.lng) >
-            kEPS
-          ) {
-            this.map_.panTo({
-              lat: currentCenter.lat,
-              lng: currentCenter.lng,
-            });
-          }
+          this.map_.panTo({
+            lat: currentCenter.lat,
+            lng: currentCenter.lng,
+          });
         }
       }
 


### PR DESCRIPTION
Execute the following steps:

1. Click 'Locate Me' button - map would be centered to the detected location.
2. Move the map.
3. Click 'Locate Me' - map would not be centered, even thougn center prop receives the expected value.

`center` prop value is not changed (on steps 1 and 3 coordinates are the same), but at the same time `center` prop value is different from actual center. Such a behavior of component might be confusing. IMHO, when deciding whether to re-center map programmatically, it makes sense to compare center value with current actual center.