### PR TITLE
Fix: React 18 markers

### DIFF
--- a/src/google_map.js
+++ b/src/google_map.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, react/forbid-prop-types, react/no-find-dom-node, no-console, no-undef */
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
+import ReactDOM, { flushSync } from 'react-dom';
 
 // helpers
 import GoogleMapMap from './google_map_map';
@@ -706,7 +706,9 @@ class GoogleMap extends Component {
             this_._onChildMouseMove();
 
             if (this_.markersDispatcher_) {
-              this_.markersDispatcher_.emit('kON_CHANGE');
+              flushSync(() => {
+                this_.markersDispatcher_.emit('kON_CHANGE');
+              })
               if (this_.fireMouseEventOnIdle_) {
                 this_.markersDispatcher_.emit('kON_MOUSE_POSITION_CHANGE');
               }

--- a/src/google_map_markers.js
+++ b/src/google_map_markers.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 // utils
 import omit from './utils/omit';
 import shallowEqual from './utils/shallowEqual';
+import { flushSync } from 'react-dom';
 
 const mainStyle = {
   width: '100%',
@@ -109,12 +110,14 @@ export default class GoogleMapMarkers extends Component {
     const prevChildCount = (this.state.children || []).length;
     const state = this._getState();
 
-    this.setState(
-      state,
-      () =>
-        (state.children || []).length !== prevChildCount &&
-        this._onMouseChangeHandler()
-    );
+    flushSync(() => {
+      this.setState(
+        state,
+        () =>
+          (state.children || []).length !== prevChildCount &&
+          this._onMouseChangeHandler()
+      );
+    });
   };
 
   _onChildClick = () => {

--- a/src/google_map_markers.js
+++ b/src/google_map_markers.js
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 // utils
 import omit from './utils/omit';
 import shallowEqual from './utils/shallowEqual';
-import { flushSync } from 'react-dom';
 
 const mainStyle = {
   width: '100%',
@@ -110,14 +109,12 @@ export default class GoogleMapMarkers extends Component {
     const prevChildCount = (this.state.children || []).length;
     const state = this._getState();
 
-    flushSync(() => {
-      this.setState(
-        state,
-        () =>
-          (state.children || []).length !== prevChildCount &&
-          this._onMouseChangeHandler()
-      );
-    });
+    this.setState(
+      state,
+      () =>
+        (state.children || []).length !== prevChildCount &&
+        this._onMouseChangeHandler()
+    );
   };
 
   _onChildClick = () => {

--- a/src/google_map_markers.js
+++ b/src/google_map_markers.js
@@ -94,7 +94,7 @@ export default class GoogleMapMarkers extends Component {
     this.props.dispatcher.removeListener('kON_CLICK', this._onChildClick);
     this.props.dispatcher.removeListener('kON_MDOWN', this._onChildMouseDown);
 
-    this.dimensionsCache_ = null;
+    this.dimensionsCache_ = {};
   }
 
   _getState = () => ({


### PR DESCRIPTION
Issue: (https://github.com/google-map-react/google-map-react/issues/1223)

This pull request addresses an issue with the markers rendering incorrectly using React `^18`. 

The issues were:
1. StrictMode behaves differently, which exposes an issue with the `dimensionsCache` property in `componentWillUnmount`.
https://react.dev/blog/2022/03/29/react-v18#new-strict-mode-behaviors
2. Batched updates, causing flickering with the markers when the map is repositioned or zoomed. Resolved by opting out of automatic batching for the marker state updates (via `flushSync`).
https://react.dev/blog/2022/03/29/react-v18#new-feature-automatic-batching

